### PR TITLE
Add missing shared text-to-speech singleton

### DIFF
--- a/Sources/MobilePassiveData/AudioSoundToolbox/VoicePrompter.swift
+++ b/Sources/MobilePassiveData/AudioSoundToolbox/VoicePrompter.swift
@@ -65,6 +65,9 @@ public protocol VoicePrompter {
 /// uses the `AVSpeechSynthesizer` to synthesize text to sound.
 public final class TextToSpeechSynthesizer : NSObject, VoicePrompter {
     
+    /// The text-to-speech synthesizer needs to be a singleton to allow crossing UI transition boundaries.
+    public static let shared = TextToSpeechSynthesizer()
+    
     /// The language code to use for the speech voice.
     public let languageCode: String
     


### PR DESCRIPTION
Still kind of beta since I want to talk to @Erin-Mounts and @nategbrown9 about result hierarchies but this fixes an issue in the "SageResearch 4.0.0-beta" with text-to-speech while transitioning views.