### PR TITLE
iOS 14.5 does not call the deprecated location status delegate method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         // Add support for all platforms starting from a specific version.
-        .macOS(.v11),
+        .macOS(.v10_15),
         .iOS(.v11),
         .watchOS(.v7),
         .tvOS(.v12)

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         // Add support for all platforms starting from a specific version.
-        .macOS(.v10_15),
+        .macOS(.v11),
         .iOS(.v11),
         .watchOS(.v5),
         .tvOS(.v12)

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // Add support for all platforms starting from a specific version.
         .macOS(.v11),
         .iOS(.v11),
-        .watchOS(.v5),
+        .watchOS(.v7),
         .tvOS(.v12)
     ],
     products: [

--- a/Sources/AudioRecorder/AudioRecorderAuthorization.swift
+++ b/Sources/AudioRecorder/AudioRecorderAuthorization.swift
@@ -87,16 +87,18 @@ public final class AudioRecorderAuthorization : PermissionAuthorizationAdaptor {
 
     /// Request authorization to record.
     static public func requestAuthorization(_ completion: @escaping ((PermissionAuthorizationStatus, Error?) -> Void)) {
-        #if os(iOS)
-        AVAudioSession.sharedInstance().requestRecordPermission { granted in
-            if granted {
-                completion(.authorized, nil)
-            } else {
-                completion(.denied, nil)
+        DispatchQueue.main.async {
+            #if os(iOS)
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                if granted {
+                    completion(.authorized, nil)
+                } else {
+                    completion(.denied, nil)
+                }
             }
+            #else
+            completion(.authorized, nil)
+            #endif
         }
-        #else
-        completion(.authorized, nil)
-        #endif
     }
 }

--- a/Sources/MotionSensor/MotionAuthorization.swift
+++ b/Sources/MotionSensor/MotionAuthorization.swift
@@ -100,23 +100,24 @@ public final class MotionAuthorization : PermissionAuthorizationAdaptor {
 
     /// Request authorization for access to the motion and fitness sensors.
     static public func requestAuthorization(_ completion: @escaping ((PermissionAuthorizationStatus, Error?) -> Void)) {
-        
-        // Request permission to use the pedometer.
-        pedometer = CMPedometer()
-        let now = Date()
-        pedometer!.queryPedometerData(from: now.addingTimeInterval(-2*60), to: now) { (_, error) in
-            DispatchQueue.main.async {
-                // Brittle work around for limitations of getting "motion & fitness" authorization status. The 104 code is sometimes thrown
-                // even if the app has the proper permissions. Ignore it. syoung 03/22/2018
-                if let err = error, (err as NSError).code != 104 {
-                    debugPrint("Failed to query pedometer: \(err)")
-                    self.setCachedAuthorization(false)
-                    let error = PermissionError.notAuthorized(StandardPermission.motion, .denied)
-                    completion(.denied, error)
-                } else {
-                    self.pedometer = nil
-                    self.setCachedAuthorization(true)
-                    completion(.authorized, nil)
+        DispatchQueue.main.async {
+            // Request permission to use the pedometer.
+            pedometer = CMPedometer()
+            let now = Date()
+            pedometer!.queryPedometerData(from: now.addingTimeInterval(-2*60), to: now) { (_, error) in
+                DispatchQueue.main.async {
+                    // Brittle work around for limitations of getting "motion & fitness" authorization status. The 104 code is sometimes thrown
+                    // even if the app has the proper permissions. Ignore it. syoung 03/22/2018
+                    if let err = error, (err as NSError).code != 104 {
+                        debugPrint("Failed to query pedometer: \(err)")
+                        self.setCachedAuthorization(false)
+                        let error = PermissionError.notAuthorized(StandardPermission.motion, .denied)
+                        completion(.denied, error)
+                    } else {
+                        self.pedometer = nil
+                        self.setCachedAuthorization(true)
+                        completion(.authorized, nil)
+                    }
                 }
             }
         }


### PR DESCRIPTION
*sigh* so this means that the validation app permissions onboarding flow will be messed up for iOS 14.5 participants. Darn.