### PR TITLE
Support JsonModel v2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "996d4807c42f0660c62b4cec0f95230dd1341639",
-          "version": "1.5.0"
+          "revision": "4431edad387697d8db879212c4ca8dacbc436b5f",
+          "version": "1.6.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "JsonModel",
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "1.5.0"),
+                 "1.6.0"..<"3.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/DistanceRecorder/DistanceRecorder.swift
+++ b/Sources/DistanceRecorder/DistanceRecorder.swift
@@ -37,6 +37,7 @@ import CoreLocation
 import CoreMotion
 import MobilePassiveData
 import JsonModel
+import ResultModel
 import MotionSensor
 
 

--- a/Sources/MobilePassiveData/AsyncActions/AsyncActionController.swift
+++ b/Sources/MobilePassiveData/AsyncActions/AsyncActionController.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// `AsyncActionVendor` is an extension of the configuration protocol for configurations that
 /// know how to vend a new controller.

--- a/Sources/MobilePassiveData/SampleRecorder/SampleRecorder.swift
+++ b/Sources/MobilePassiveData/SampleRecorder/SampleRecorder.swift
@@ -34,6 +34,7 @@
 import Foundation
 import Combine
 import JsonModel
+import ResultModel
 
 public protocol ClockProxy : AnyObject {
 

--- a/Sources/MobilePassiveData/Serialization/MobilePassiveDataFactory.swift
+++ b/Sources/MobilePassiveData/Serialization/MobilePassiveDataFactory.swift
@@ -32,6 +32,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// `MobilePassiveDataFactory` is a subclass of the `ResultDataFactory` that registers a serializer
 /// for `AsyncActionConfiguration` objects that can be used to deserialize the results.

--- a/Sources/MobilePassiveData/Serialization/Results/WeatherResult.swift
+++ b/Sources/MobilePassiveData/Serialization/Results/WeatherResult.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 extension SerializableResultType {
     public static let weather: SerializableResultType = "weather"

--- a/Sources/WeatherRecorder/WeatherRecorder.swift
+++ b/Sources/WeatherRecorder/WeatherRecorder.swift
@@ -34,6 +34,7 @@ import Foundation
 import CoreLocation
 import MobilePassiveData
 import JsonModel
+import ResultModel
 import LocationAuthorization
 
 public typealias WeatherServiceCompletionHandler = (WeatherService, [WeatherServiceResponse]?, Error?) -> Void


### PR DESCRIPTION
See https://github.com/Sage-Bionetworks/JsonModel-Swift/pull/24

On iOS, MobilePassiveData is a shared library imported by both SageResearch and AssessmentModel. This will allow the library to pin to either JsonModel v1.6 or v2 and build for both.

This build also fixes a warning about the main actor where it cannot be assumed that notifications are called on the main actor starting in Swift 6.0