### PR TITLE
Explicitly copy the ivar to a let before passing to an init

### DIFF
--- a/Sources/MobilePassiveData/SampleRecorder/SampleRecorder.swift
+++ b/Sources/MobilePassiveData/SampleRecorder/SampleRecorder.swift
@@ -357,7 +357,11 @@ open class SampleRecorder : NSObject, AsyncActionController, ObservableObject {
     
     @MainActor public final func stepPath(for timestamp: SystemUptime) -> String {
         let uptime = clock.relativeUptime(to: timestamp)
-        return markers.first(where: { $0.uptime < uptime }).map { $0.stepPath } ?? currentStepPath
+        return stepPath(uptime: uptime)
+    }
+    
+    @MainActor public final func stepPath(uptime: ClockUptime) -> String {
+        markers.first(where: { $0.uptime < uptime }).map { $0.stepPath } ?? currentStepPath
     }
     
     /// This method should be called on the main thread with the completion handler also called on

--- a/Sources/MotionSensor/MotionRecorder.swift
+++ b/Sources/MotionSensor/MotionRecorder.swift
@@ -253,10 +253,11 @@ open class MotionRecorder : SampleRecorder {
         guard !isPaused else { return }
         let frame = motionManager?.attitudeReferenceFrame ?? CMAttitudeReferenceFrame.xArbitraryZVertical
         Task {
-            async let uptime = clock.relativeUptime(to: data.timestamp)
-            async let timestamp = clock.zeroRelativeTime(to: data.timestamp)
-            async let stepPath = stepPath(for: data.timestamp)
-            let samples = await samples(from: data, frame: frame, stepPath: stepPath, uptime: uptime, timestamp: timestamp)
+            let dataTimestamp = data.timestamp
+            let uptime = await clock.relativeUptime(to: dataTimestamp)
+            let timestamp = await clock.zeroRelativeTime(to: dataTimestamp)
+            let stepPath = await stepPath(uptime: uptime)
+            let samples = samples(from: data, frame: frame, stepPath: stepPath, uptime: uptime, timestamp: timestamp)
             self.writeSamples(samples)
         }
     }


### PR DESCRIPTION
Getting an occasional crash in the implicit copy of the Swift ivar so instead of letting Swift control the threading for calculating each value, do so manually.

<img width="1030" alt="Screenshot 2023-01-03 at 2 03 42 PM" src="https://user-images.githubusercontent.com/5649217/210448822-0e335fd0-9cc3-484b-b084-b1a502cf690f.png">
