### PR TITLE
Default to deleting previous microphone levels on restart

### DIFF
--- a/Sources/MobilePassiveData/Serialization/AsyncActionConfigurations/AudioRecorderConfigurationObject.swift
+++ b/Sources/MobilePassiveData/Serialization/AsyncActionConfigurations/AudioRecorderConfigurationObject.swift
@@ -23,9 +23,9 @@ import JsonModel
 ///            }
 ///            """.data(using: .utf8)! // our data in native (JSON) format
 /// ```
-public struct AudioRecorderConfigurationObject : RecorderConfiguration, Codable {
+public struct AudioRecorderConfigurationObject : RestartableRecorderConfiguration, Codable {
     private enum CodingKeys : String, OrderedEnumCodingKey {
-        case identifier, asyncActionType = "type", startStepIdentifier, stopStepIdentifier, _requiresBackgroundAudio = "requiresBackgroundAudio", saveAudioFile = "saveAudioFile"
+        case identifier, asyncActionType = "type", startStepIdentifier, stopStepIdentifier, _requiresBackgroundAudio = "requiresBackgroundAudio", saveAudioFile = "saveAudioFile", _shouldDeletePrevious = "shouldDeletePrevious"
     }
     
     /// A short string that uniquely identifies the asynchronous action within the task. If started
@@ -57,6 +57,13 @@ public struct AudioRecorderConfigurationObject : RecorderConfiguration, Codable 
     }
     private let _requiresBackgroundAudio: Bool?
     
+    /// Should the previous recording be deleted on restart?
+    public var shouldDeletePrevious: Bool {
+        return _shouldDeletePrevious ?? true
+    }
+    private let _shouldDeletePrevious: Bool?
+    
+    
     /// Should the audio recording be saved? Default = `false`.
     ///
     /// If `true` then the audio file used to measure meter levels is saved with the results.
@@ -70,12 +77,13 @@ public struct AudioRecorderConfigurationObject : RecorderConfiguration, Codable 
     ///     - motionStepIdentifier: Optional identifier for the step that records distance travelled.
     ///     - startStepIdentifier: An identifier marking the step to start the action. Default = `nil`.
     ///     - stopStepIdentifier: An identifier marking the step to stop the action.  Default = `nil`.
-    public init(identifier: String, startStepIdentifier: String? = nil, stopStepIdentifier: String? = nil, requiresBackgroundAudio: Bool = false, saveAudioFile: Bool? = nil) {
+    public init(identifier: String, startStepIdentifier: String? = nil, stopStepIdentifier: String? = nil, requiresBackgroundAudio: Bool = false, saveAudioFile: Bool? = nil, shouldDeletePrevious: Bool? = nil) {
         self.identifier = identifier
         self.startStepIdentifier = startStepIdentifier
         self.stopStepIdentifier = stopStepIdentifier
         self._requiresBackgroundAudio = requiresBackgroundAudio
         self.saveAudioFile = saveAudioFile
+        self._shouldDeletePrevious = shouldDeletePrevious
     }
     
     /// Returns `location` and `motion` on iOS. Returns an empty set on platforms that do not
@@ -117,7 +125,7 @@ extension AudioRecorderConfigurationObject : DocumentableStruct {
             return .init(propertyType: .primitive(.string))
         case .startStepIdentifier, .stopStepIdentifier:
             return .init(propertyType: .primitive(.string))
-        case ._requiresBackgroundAudio, .saveAudioFile:
+        case ._requiresBackgroundAudio, .saveAudioFile, ._shouldDeletePrevious:
             return .init(propertyType: .primitive(.boolean))
         }
     }

--- a/passiveData/src/androidMain/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/FlowJsonFileResultRecorder.kt
+++ b/passiveData/src/androidMain/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/FlowJsonFileResultRecorder.kt
@@ -43,7 +43,7 @@ abstract class FlowJsonFileResultRecorder<in E>(
     private val isFirstJsonObject = AtomicBoolean(true)
 
     override fun start() {
-        file = getTaskOutputFile("$identifier.json")
+        file = getTaskOutputFile("${defaultLoggerIdentifier()}.json")
         filePrintStream = PrintStream(file)
         filePrintStream.print(JSON_FILE_START)
         super.start()
@@ -71,6 +71,21 @@ abstract class FlowJsonFileResultRecorder<in E>(
     }
 
     abstract fun serializeElement(e: E)
+
+    /**
+     * The default logger is a file with markers for each step transition.
+     *
+     * Recorders can have multiple files associated with them. For example, an
+     * audio recorder ("microphone") can record audio to an mp4 and microphone
+     * levels to a log file. In that case, by convention, the primary file is
+     * has the filename "microphone.mp4" and the secondary logging file that
+     * logs the microphone levels is named "microphone_levels.json".
+     *
+     * - Note: This library does not currently support non-JSON recordings, but
+     * is structured this way to keep it consistent with iOS where mp4, jpeg, etc.
+     * have been supported for previously implemented assessments. syoung 04/27/2023
+     */
+    open fun defaultLoggerIdentifier(): String = identifier
 
     override fun completedHandlingFlow(e: Throwable?) {
         Napier.i("Completed handling flow")

--- a/passiveData/src/androidMain/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/audio/AudioRecorder.kt
+++ b/passiveData/src/androidMain/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/audio/AudioRecorder.kt
@@ -24,6 +24,13 @@ public class AudioRecorder(
 
     var firstEventUptimeReference = AtomicReference<Long>()
 
+    /**
+     * Using "microphone" as a permission and default identifier was originally mapped to
+     * audio recordings in older applications, so recording the "microphone levels" as the
+     * default JSON log file requires changing the default filename.
+     */
+    override fun defaultLoggerIdentifier(): String = "${super.defaultLoggerIdentifier()}_levels"
+
     override fun serializeElement(e: Int) {
         var timestampDate : Instant? = null
         val now = Clock.System.now()


### PR DESCRIPTION
I ended up fixing https://sagebionetworks.jira.com/browse/DHP-901 for both iOS and Android.

- iOS: Changed the default behavior when an assessment is "continued" to delete the previous recording.

- Android: Append "_levels" to the json file b/c "microphone.mp4" previously existed as the default naming convention for microphone recordings.