### PR TITLE
[DHP-905] Do not encode “null” weather results

### DIFF
--- a/passiveData/src/commonMain/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/weather/WeatherResult.kt
+++ b/passiveData/src/commonMain/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/weather/WeatherResult.kt
@@ -2,15 +2,18 @@ package org.sagebionetworks.assessmentmodel.passivedata.recorder.weather
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.sagebionetworks.assessmentmodel.JsonArchivableFile
 import org.sagebionetworks.assessmentmodel.JsonFileArchivableResult
-import org.sagebionetworks.assessmentmodel.Result
 import org.sagebionetworks.assessmentmodel.passivedata.recorder.weather.WeatherServiceTypeStrings.TYPE_WEATHER
 import org.sagebionetworks.assessmentmodel.serialization.InstantSerializer
+
+@OptIn(ExperimentalSerializationApi::class)
+internal val weatherResultCoder = Json { explicitNulls = false }
 
 @Serializable
 @SerialName(TYPE_WEATHER)
@@ -33,7 +36,7 @@ data class WeatherResult(
     override fun getJsonArchivableFile(stepPath: String): JsonArchivableFile {
         return JsonArchivableFile(
             filename = "$identifier.json",
-            json = Json.encodeToString(this),
+            json = weatherResultCoder.encodeToString(this),
             jsonSchema = "https://sage-bionetworks.github.io/mobile-client-json/schemas/v2/WeatherResult.json"
         )
     }

--- a/passiveData/src/commonTest/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/weather/WeatherResultTest.kt
+++ b/passiveData/src/commonTest/kotlin/org/sagebionetworks/assessmentmodel/passivedata/recorder/weather/WeatherResultTest.kt
@@ -5,12 +5,11 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.modules.plus
 import org.sagebionetworks.assessmentmodel.Result
 import org.sagebionetworks.assessmentmodel.passivedata.resultDataSerializersModule
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class WeatherResultTest {
     @Serializable
@@ -33,6 +32,18 @@ class WeatherResultTest {
         val deserialized = jsonCoder.decodeFromString<ResultDataWrapper>(json)
 
         assertTrue(deserialized.resultData is WeatherResult)
+    }
+
+    @Test
+    fun testNullResult() {
+        val weatherResult = WeatherResult("identifier", weather = null, airQuality = null)
+
+        val json = weatherResult.getJsonArchivableFile("foo").json
+        val deserialized = Json.decodeFromString<JsonObject>(json)
+
+        assertNull(deserialized["weather"])
+        assertNull(deserialized["airQuality"])
+        assertFalse(json.contains("null"))
     }
 
     @Test


### PR DESCRIPTION
The JSON encoding for all results should ignore `null` values and not add them to the encoded JSON as `null`. Unfortunately, this isn't the default for Kotlin serialization and has to be set explicitly.

https://sagebionetworks.jira.com/browse/DHP-905